### PR TITLE
Factor admin commands out into their own files, kill do_admin

### DIFF
--- a/commands/abuse.py
+++ b/commands/abuse.py
@@ -18,7 +18,7 @@ from helpers import arguments
 from helpers.command import Command
 
 
-@Command('abuse', ['config', 'handler'], adminonly=True)
+@Command('abuse', ['config', 'handler'], admin=True)
 def cmd(send, msg, args):
     """Shows or clears the abuse list
     Syntax: !abuse (--clear) (--show)

--- a/commands/abuse.py
+++ b/commands/abuse.py
@@ -1,0 +1,35 @@
+# Copyright (C) 2013-2015 Samuel Damashek, Peter Foley, James Forcier, Srijay Kasturi, Reed Koser, Christopher Reffett, and Fox Wilson
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+from helpers import arguments
+from helpers.command import Command
+
+
+@Command('abuse', ['config', 'handler'], adminonly=True)
+def cmd(send, msg, args):
+    """Shows or clears the abuse list
+    Syntax: !abuse (--clear) (--show)
+    """
+    parser = arguments.ArgParser(args['config'])
+    parser.add_argument('--clear', action='store_true')
+    parser.add_argument('--show', action='store_true')
+    cmdargs = parser.parse_args(msg)
+    if cmdargs.clear:
+        args['handler'].abuselist = {}
+        send("Abuse list cleared.")
+    elif cmdargs.show:
+        abusers = [x for x in args['handler'].abuselist.keys() if x in args['handler'].ignored]
+        send(", ".join(abusers))

--- a/commands/cadmin.py
+++ b/commands/cadmin.py
@@ -1,0 +1,28 @@
+# Copyright (C) 2013-2015 Samuel Damashek, Peter Foley, James Forcier, Srijay Kasturi, Reed Koser, Christopher Reffett, and Fox Wilson
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+from helpers.command import Command
+
+
+@Command('cadmin', ['handler'], admin=True)
+def cmd(send, msg, args):
+    """Clears the verified admin list
+    Syntax: !cadmin
+    """
+    admins = [x.strip() for x in args['handler'].config['auth']['admins'].split(',')]
+    args['handler'].admins = {nick: False for nick in admins}
+    args['handler'].get_admins(args['handler'].connection)
+    send("Verified admins reset.")

--- a/commands/ignore.py
+++ b/commands/ignore.py
@@ -1,0 +1,51 @@
+# Copyright (C) 2013-2015 Samuel Damashek, Peter Foley, James Forcier, Srijay Kasturi, Reed Koser, Christopher Reffett, and Fox Wilson
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+from helpers import arguments
+from helpers.command import Command
+
+
+@Command('ignore', ['config', 'handler'], admin=True)
+def cmd(send, msg, args):
+    """Handles ignoring/unignoring people
+    Syntax: !ignore (--clear) (--show/--list) (--delete) nick
+    """
+    parser = arguments.ArgParser(args['config'])
+    parser.add_argument('nick', nargs='?')
+    parser.add_argument('--clear', action='store_true')
+    parser.add_argument('--show', '--list', action='store_true')
+    parser.add_argument('--delete', action='store_true')
+    cmdargs = parser.parse_args(msg)
+    if cmdargs.clear:
+        args['handler'].ignored = []
+        send("Ignore list cleared.")
+    elif cmdargs.show:
+        if args['handler'].ignored:
+            send(", ".join(args['handler'].ignored))
+        else:
+            send("Nobody is ignored.")
+    elif cmdargs.delete:
+        if not cmdargs.nick:
+            send("Unignore who?")
+        elif cmdargs.nick not in args['handler'].ignored:
+            send("%s is not ignored." % cmdargs.nick)
+        else:
+            args['handler'].ignored.remove(cmdargs.nick)
+            send("%s is no longer ignored." % cmdargs.nick)
+    elif cmdargs.nick:
+        args['handler'].ignore(send, cmdargs.nick)
+    else:
+        send("Ignore who?")

--- a/commands/join.py
+++ b/commands/join.py
@@ -1,0 +1,30 @@
+# Copyright (C) 2013-2015 Samuel Damashek, Peter Foley, James Forcier, Srijay Kasturi, Reed Koser, Christopher Reffett, and Fox Wilson
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+from helpers import arguments
+from helpers.command import Command
+
+
+@Command('join', ['handler', 'config', 'nick', 'type'], admin=True)
+def cmd(send, msg, args):
+    """Orders the bot to join a channel
+    Syntax: !join (channel)
+    """
+    parser = arguments.ArgParser(args['config'])
+    parser.add_argument('channel', nargs='+')
+    cmdargs = parser.parse_args(msg)
+    for chan in cmdargs.channel:
+        args['handler'].do_join(chan, args['nick'], args['type'], send, args['handler'].connection)

--- a/commands/part.py
+++ b/commands/part.py
@@ -1,0 +1,30 @@
+# Copyright (C) 2013-2015 Samuel Damashek, Peter Foley, James Forcier, Srijay Kasturi, Reed Koser, Christopher Reffett, and Fox Wilson
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+from helpers import arguments
+from helpers.command import Command
+
+
+@Command('part', ['handler', 'config', 'nick', 'type', 'target'], admin=True)
+def cmd(send, msg, args):
+    """Orders the bot to join a channel
+    Syntax: !part (channel)
+    """
+    parser = arguments.ArgParser(args['config'])
+    parser.add_argument('channel', nargs='+')
+    cmdargs = parser.parse_args(msg)
+    for chan in cmdargs.channel:
+        args['handler'].do_part(chan, args['nick'], args['type'], args['target'], send, args['handler'].connection)

--- a/commands/quit.py
+++ b/commands/quit.py
@@ -1,0 +1,27 @@
+# Copyright (C) 2013-2015 Samuel Damashek, Peter Foley, James Forcier, Srijay Kasturi, Reed Koser, Christopher Reffett, and Fox Wilson
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+import sys
+from helpers.command import Command
+
+
+@Command('quit', ['handler'], admin=True)
+def cmd(send, msg, args):
+    """Makes the bot disconnect and shut off
+    Syntax: !quit
+    """
+    args['handler'].connection.disconnect('Goodbye, Cruel World!')
+    sys.exit(0)

--- a/config.example
+++ b/config.example
@@ -17,7 +17,7 @@ chanregex: [#&+!][a-zA-Z0-9_-!#]*
 extracommands:
 [groups]
 hooks: core, optional
-commands: core, useful, optional
+commands: admin, core, useful, optional
 [auth]
 ctrlpass:
 nickpass:

--- a/handler.py
+++ b/handler.py
@@ -18,7 +18,6 @@
 
 import re
 import time
-import sys
 from helpers import control
 from helpers import sql
 from helpers import hook
@@ -332,11 +331,6 @@ class BotHandler():
             else:
                 msg = textutils.gen_slogan(msg).upper() if slogan else msg
                 self.connection.kick(target, nick, msg)
-
-    def do_admin(self, c, cmd, cmdargs, send, nick, msgtype, target):
-        if cmd == 'quit':
-            c.disconnect('Goodbye, Cruel World!')
-            sys.exit(0)
 
     def do_args(self, modargs, send, nick, target, source, name, msgtype):
         """ Handle the various args that modules need."""

--- a/handler.py
+++ b/handler.py
@@ -334,9 +334,7 @@ class BotHandler():
                 self.connection.kick(target, nick, msg)
 
     def do_admin(self, c, cmd, cmdargs, send, nick, msgtype, target):
-        if cmd == 'part':
-            self.do_part(cmdargs, nick, target, msgtype, send, c)
-        elif cmd == 'quit':
+        if cmd == 'quit':
             c.disconnect('Goodbye, Cruel World!')
             sys.exit(0)
 

--- a/handler.py
+++ b/handler.py
@@ -335,12 +335,7 @@ class BotHandler():
                 self.connection.kick(target, nick, msg)
 
     def do_admin(self, c, cmd, cmdargs, send, nick, msgtype, target):
-        if cmd == 'cadmin':
-            admins = [x.strip() for x in self.config['auth']['admins'].split(',')]
-            self.admins = {nick: False for nick in admins}
-            self.get_admins(c)
-            send("Verified admins reset.")
-        elif cmd == 'ignore':
+        if cmd == 'ignore':
             parser = arguments.ArgParser(self.config)
             parser.add_argument('nick', nargs='?')
             parser.add_argument('--clear', action='store_true')

--- a/handler.py
+++ b/handler.py
@@ -334,9 +334,7 @@ class BotHandler():
                 self.connection.kick(target, nick, msg)
 
     def do_admin(self, c, cmd, cmdargs, send, nick, msgtype, target):
-        if cmd == 'join':
-            self.do_join(cmdargs, nick, msgtype, send, c)
-        elif cmd == 'part':
+        if cmd == 'part':
             self.do_part(cmdargs, nick, target, msgtype, send, c)
         elif cmd == 'quit':
             c.disconnect('Goodbye, Cruel World!')

--- a/handler.py
+++ b/handler.py
@@ -490,8 +490,8 @@ class BotHandler():
                 cmd_obj = command.get_command(cmd_name)
                 if cmd_obj.is_limited() and self.abusecheck(send, nick, target, cmd_obj.limit, cmd[len(cmdchar):]):
                     return
-                if cmd_obj.is_admin_only() and not self.is_admin(send, nick):
-                    send("This command requires admin privileges")
+                if cmd_obj.requires_admin() and not self.is_admin(send, nick):
+                    send("This command requires admin privileges.")
                     return
                 args = self.do_args(cmd_obj.args, send, nick, target, e.source, cmd_name, msgtype)
                 cmd_obj.run(send, cmdargs, args, cmd_name, nick, target, self)

--- a/handler.py
+++ b/handler.py
@@ -335,14 +335,7 @@ class BotHandler():
                 self.connection.kick(target, nick, msg)
 
     def do_admin(self, c, cmd, cmdargs, send, nick, msgtype, target):
-        if cmd == 'abuse':
-            if cmdargs == 'clear':
-                self.abuselist = {}
-                send("Abuse list cleared.")
-            elif cmdargs == 'show':
-                abusers = [x for x in self.abuselist.keys() if x in self.ignored]
-                send(", ".join(abusers))
-        elif cmd == 'cadmin':
+        if cmd == 'cadmin':
             admins = [x.strip() for x in self.config['auth']['admins'].split(',')]
             self.admins = {nick: False for nick in admins}
             self.get_admins(c)
@@ -497,7 +490,7 @@ class BotHandler():
                 cmd_obj = command.get_command(cmd_name)
                 if cmd_obj.is_limited() and self.abusecheck(send, nick, target, cmd_obj.limit, cmd[len(cmdchar):]):
                     return
-                if cmd_obj.is_adminonly() and not self.is_admin(send, nick):
+                if cmd_obj.is_admin_only() and not self.is_admin(send, nick):
                     send("This command requires admin privileges")
                     return
                 args = self.do_args(cmd_obj.args, send, nick, target, e.source, cmd_name, msgtype)

--- a/handler.py
+++ b/handler.py
@@ -491,22 +491,18 @@ class BotHandler():
                 cmd = cmd.split(match.group(1))[0]
                 cmdlen = len(cmd)
         cmdargs = msg[cmdlen:]
-        found = False
         if cmd.startswith(cmdchar):
             cmd_name = cmd[len(cmdchar):]
             if command.is_registered(cmd_name):
-                found = True
                 cmd_obj = command.get_command(cmd_name)
                 if cmd_obj.is_limited() and self.abusecheck(send, nick, target, cmd_obj.limit, cmd[len(cmdchar):]):
                     return
+                if cmd_obj.is_adminonly() and not self.is_admin(send, nick):
+                    send("This command requires admin privileges")
+                    return
                 args = self.do_args(cmd_obj.args, send, nick, target, e.source, cmd_name, msgtype)
                 cmd_obj.run(send, cmdargs, args, cmd_name, nick, target, self)
-        # special commands
-        if cmd.startswith(cmdchar):
-            if cmd[len(cmdchar):] == 'reload':
+            # special commands
+            elif cmd[len(cmdchar):] == 'reload':
                 if nick in admins:
-                    found = True
                     send("Aye Aye Capt'n")
-            # everything below this point requires admin
-            if not found and self.is_admin(send, nick):
-                self.do_admin(c, cmd[len(cmdchar):], cmdargs, send, nick, msgtype, target)

--- a/handler.py
+++ b/handler.py
@@ -19,7 +19,6 @@
 import re
 import time
 import sys
-from helpers import arguments
 from helpers import control
 from helpers import sql
 from helpers import hook
@@ -335,34 +334,7 @@ class BotHandler():
                 self.connection.kick(target, nick, msg)
 
     def do_admin(self, c, cmd, cmdargs, send, nick, msgtype, target):
-        if cmd == 'ignore':
-            parser = arguments.ArgParser(self.config)
-            parser.add_argument('nick', nargs='?')
-            parser.add_argument('--clear', action='store_true')
-            parser.add_argument('--show', '--list', action='store_true')
-            parser.add_argument('--delete', action='store_true')
-            cmdargs = parser.parse_args(cmdargs)
-            if cmdargs.clear:
-                self.ignored = []
-                send("Ignore list cleared.")
-            elif cmdargs.show:
-                if self.ignored:
-                    send(", ".join(self.ignored))
-                else:
-                    send("Nobody is ignored.")
-            elif cmdargs.delete:
-                if not cmdargs.nick:
-                    send("Unignore who?")
-                elif cmdargs.nick not in self.ignored:
-                    send("%s is not ignored." % cmdargs.nick)
-                else:
-                    self.ignored.remove(cmdargs.nick)
-                    send("%s is no longer ignored." % cmdargs.nick)
-            elif cmdargs.nick:
-                self.ignore(send, cmdargs.nick)
-            else:
-                send("Ignore who?")
-        elif cmd == 'join':
+        if cmd == 'join':
             self.do_join(cmdargs, nick, msgtype, send, c)
         elif cmd == 'part':
             self.do_part(cmdargs, nick, target, msgtype, send, c)

--- a/helpers/command.py
+++ b/helpers/command.py
@@ -100,11 +100,12 @@ def check_command(cursor, nick, msg, target):
 
 class Command():
 
-    def __init__(self, names, args=[], limit=0):
+    def __init__(self, names, args=[], limit=0, adminonly=False):
         global _known_commands
         self.names = [names] if isinstance(names, str) else names
         self.args = args
         self.limit = limit
+        self.adminonly = adminonly
         for t in self.names:
             if t in _known_commands:
                 raise ValueError("There is already a command registered with the name %s" % t)
@@ -144,3 +145,6 @@ class Command():
 
     def is_limited(self):
         return self.limit != 0
+
+    def is_admin_only(self):
+        return self.adminonly

--- a/helpers/command.py
+++ b/helpers/command.py
@@ -100,12 +100,12 @@ def check_command(cursor, nick, msg, target):
 
 class Command():
 
-    def __init__(self, names, args=[], limit=0, adminonly=False):
+    def __init__(self, names, args=[], limit=0, admin=False):
         global _known_commands
         self.names = [names] if isinstance(names, str) else names
         self.args = args
         self.limit = limit
-        self.adminonly = adminonly
+        self.admin = admin
         for t in self.names:
             if t in _known_commands:
                 raise ValueError("There is already a command registered with the name %s" % t)
@@ -146,5 +146,5 @@ class Command():
     def is_limited(self):
         return self.limit != 0
 
-    def is_admin_only(self):
-        return self.adminonly
+    def requires_admin(self):
+        return self.admin

--- a/helpers/groups.cfg
+++ b/helpers/groups.cfg
@@ -3,7 +3,7 @@ core: caps, note, scores, url, babble
 optional: band, butt, understanding, reddit
 disabled: bob, ctf, stallman, xkcd, autodeop
 [commands]
-admin: abuse
+admin: abuse, cadmin
 core: about, admins, cancel, channels, defersay, guarded, help, highlight,
     hooks, mission, mode, msg, nicks, note, pull, score, seen, s, stats,
     threads, timeout, uptime, version, vote

--- a/helpers/groups.cfg
+++ b/helpers/groups.cfg
@@ -3,7 +3,7 @@ core: caps, note, scores, url, babble
 optional: band, butt, understanding, reddit
 disabled: bob, ctf, stallman, xkcd, autodeop
 [commands]
-admin: abuse, cadmin, ignore, join
+admin: abuse, cadmin, ignore, join, part
 core: about, admins, cancel, channels, defersay, guarded, help, highlight,
     hooks, mission, mode, msg, nicks, note, pull, score, seen, s, stats,
     threads, timeout, uptime, version, vote

--- a/helpers/groups.cfg
+++ b/helpers/groups.cfg
@@ -3,7 +3,7 @@ core: caps, note, scores, url, babble
 optional: band, butt, understanding, reddit
 disabled: bob, ctf, stallman, xkcd, autodeop
 [commands]
-admin: abuse, cadmin
+admin: abuse, cadmin, ignore
 core: about, admins, cancel, channels, defersay, guarded, help, highlight,
     hooks, mission, mode, msg, nicks, note, pull, score, seen, s, stats,
     threads, timeout, uptime, version, vote

--- a/helpers/groups.cfg
+++ b/helpers/groups.cfg
@@ -3,7 +3,7 @@ core: caps, note, scores, url, babble
 optional: band, butt, understanding, reddit
 disabled: bob, ctf, stallman, xkcd, autodeop
 [commands]
-admin: abuse, cadmin, ignore
+admin: abuse, cadmin, ignore, join
 core: about, admins, cancel, channels, defersay, guarded, help, highlight,
     hooks, mission, mode, msg, nicks, note, pull, score, seen, s, stats,
     threads, timeout, uptime, version, vote

--- a/helpers/groups.cfg
+++ b/helpers/groups.cfg
@@ -3,6 +3,7 @@ core: caps, note, scores, url, babble
 optional: band, butt, understanding, reddit
 disabled: bob, ctf, stallman, xkcd, autodeop
 [commands]
+admin: abuse
 core: about, admins, cancel, channels, defersay, guarded, help, highlight,
     hooks, mission, mode, msg, nicks, note, pull, score, seen, s, stats,
     threads, timeout, uptime, version, vote

--- a/helpers/groups.cfg
+++ b/helpers/groups.cfg
@@ -3,7 +3,7 @@ core: caps, note, scores, url, babble
 optional: band, butt, understanding, reddit
 disabled: bob, ctf, stallman, xkcd, autodeop
 [commands]
-admin: abuse, cadmin, ignore, join, part
+admin: abuse, cadmin, ignore, join, part, quit
 core: about, admins, cancel, channels, defersay, guarded, help, highlight,
     hooks, mission, mode, msg, nicks, note, pull, score, seen, s, stats,
     threads, timeout, uptime, version, vote


### PR DESCRIPTION
Note that you will need to update your commands list in config.cfg. I split it into its own list because I can see a few ways to have a dedicated admin command list--programatically detect that they need admin (so people can customize what commands should be admin-only), prevent these commands from being disabled, things like that.