### PR TITLE
Sorta-kinda fix ^C and !quit

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -131,7 +131,7 @@ class IrcBot(SingleServerIRCBot):
     def kill(self):
         """ forcibly kills everything """
         if hasattr(self, 'handler'):
-            self.handler.workers.kill_workers()
+            self.handler.kill()
         self.shutdown_server()
 
     def do_reload(self, c, target, cmdargs):

--- a/commands/quit.py
+++ b/commands/quit.py
@@ -14,7 +14,6 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-import sys
 from helpers.command import Command
 
 
@@ -23,5 +22,4 @@ def cmd(send, msg, args):
     """Makes the bot disconnect and shut off
     Syntax: !quit
     """
-    args['handler'].connection.disconnect('Goodbye, Cruel World!')
-    sys.exit(0)
+    args['handler'].shutdown()

--- a/handler.py
+++ b/handler.py
@@ -18,6 +18,7 @@
 
 import re
 import time
+import sys
 from helpers import control
 from helpers import sql
 from helpers import hook
@@ -357,6 +358,16 @@ class BotHandler():
             else:
                 raise Exception("Invalid Argument: %s" % arg)
         return realargs
+
+    def shutdown(self):
+        """ Cleanly shut ourself down """
+        self.send(self.config['core']['ctrlchan'], self.connection.real_nickname, 'Please ^C me, I won\'t die all the way =(', 'privmsg')
+        self.connection.disconnect('Goodbye, Cruel World!')
+        self.workers.stop_workers()
+
+    def kill(self):
+        """ Forcibly kill ourself """
+        self.workers.kill_workers()
 
     def is_ignored(self, nick):
         return nick in self.ignored

--- a/helpers/workers.py
+++ b/helpers/workers.py
@@ -18,6 +18,7 @@ import re
 import threading
 import multiprocessing
 import concurrent.futures
+import logging
 from collections import namedtuple
 from threading import Timer
 from .traceback import handle_traceback
@@ -104,10 +105,13 @@ class Workers():
     def kill_workers(self):
         """ Forcibly kill all worker threads """
         with executor_lock:
+            logging.info("Forcibly shutting down executor")
             self.executor.shutdown(False)
             del self.executor
         with worker_lock:
+            logging.info("Killing pool")
             self.pool.terminate()
+            logging.info("Joining pool")
             self.pool.join()
             del self.pool
             for x in self.events.values():


### PR DESCRIPTION
^C now works a little better if you don't look at the threading machinery funny on the way through the door, and !quit is slightly less broken... it kills most of the bot at least, though enough is alive to rejoin the channel as a spooky zombie. In all likelyhood !quit should probably be disabled until I can do the full threading rewrite and clean up a lot of this mess.