### PR TITLE
Make alembic play nice with sqlite

### DIFF
--- a/cslbot/alembic/env.py
+++ b/cslbot/alembic/env.py
@@ -85,7 +85,8 @@ def run_migrations_online():
     with connectable.connect() as connection:
         context.configure(
             connection=connection,
-            target_metadata=target_metadata
+            target_metadata=target_metadata,
+            render_as_batch=True
         )
 
         with context.begin_transaction():

--- a/cslbot/alembic/versions/4d165186b4ed_fix_nullable.py
+++ b/cslbot/alembic/versions/4d165186b4ed_fix_nullable.py
@@ -20,30 +20,60 @@ depends_on = None
 
 
 def upgrade():
-    op.alter_column('babble', 'key',
-                    existing_type=sa.VARCHAR(length=512),
-                    nullable=True)
-    op.alter_column('babble', 'source',
-                    existing_type=sa.TEXT(),
-                    nullable=True)
-    op.alter_column('babble', 'target',
-                    existing_type=sa.TEXT(),
-                    nullable=True)
-    op.alter_column('babble', 'word',
-                    existing_type=sa.TEXT(),
-                    nullable=True)
+    if op.get_bind().dialect.name == 'sqlite':
+        with op.batch_alter_table('babble') as batch_op:
+            batch_op.alter_column('key',
+                                  existing_type=sa.VARCHAR(length=512),
+                                  nullable=True)
+            batch_op.alter_column('source',
+                                  existing_type=sa.TEXT(),
+                                  nullable=True)
+            batch_op.alter_column('target',
+                                  existing_type=sa.TEXT(),
+                                  nullable=True)
+            batch_op.alter_column('word',
+                                  existing_type=sa.TEXT(),
+                                  nullable=True)
+    else:
+        op.alter_column('babble', 'key',
+                        existing_type=sa.VARCHAR(length=512),
+                        nullable=True)
+        op.alter_column('babble', 'source',
+                        existing_type=sa.TEXT(),
+                        nullable=True)
+        op.alter_column('babble', 'target',
+                        existing_type=sa.TEXT(),
+                        nullable=True)
+        op.alter_column('babble', 'word',
+                        existing_type=sa.TEXT(),
+                        nullable=True)
 
 
 def downgrade():
-    op.alter_column('babble', 'word',
-                    existing_type=sa.TEXT(),
-                    nullable=False)
-    op.alter_column('babble', 'target',
-                    existing_type=sa.TEXT(),
-                    nullable=False)
-    op.alter_column('babble', 'source',
-                    existing_type=sa.TEXT(),
-                    nullable=False)
-    op.alter_column('babble', 'key',
-                    existing_type=sa.VARCHAR(length=512),
-                    nullable=False)
+    if op.get_bind().dialect.name == 'sqlite':
+        with op.batch_alter_table('babble') as batch_op:
+            batch_op.alter_column('word',
+                                  existing_type=sa.TEXT(),
+                                  nullable=False)
+            batch_op.alter_column('target',
+                                  existing_type=sa.TEXT(),
+                                  nullable=False)
+            batch_op.alter_column('source',
+                                  existing_type=sa.TEXT(),
+                                  nullable=False)
+            batch_op.alter_column('key',
+                                  existing_type=sa.VARCHAR(length=512),
+                                  nullable=False)
+    else:
+        op.alter_column('babble', 'word',
+                        existing_type=sa.TEXT(),
+                        nullable=False)
+        op.alter_column('babble', 'target',
+                        existing_type=sa.TEXT(),
+                        nullable=False)
+        op.alter_column('babble', 'source',
+                        existing_type=sa.TEXT(),
+                        nullable=False)
+        op.alter_column('babble', 'key',
+                        existing_type=sa.VARCHAR(length=512),
+                        nullable=False)

--- a/cslbot/alembic/versions/55efdbb748c_merge_pending.py
+++ b/cslbot/alembic/versions/55efdbb748c_merge_pending.py
@@ -9,6 +9,8 @@ Create Date: 2015-09-02 13:35:57.956516
 
 from alembic import op
 
+import sqlalchemy as sa
+
 # revision identifiers, used by Alembic.
 revision = '55efdbb748c'
 down_revision = '385c29e42d9'
@@ -17,8 +19,18 @@ depends_on = None
 
 
 def upgrade():
-    op.alter_column('quotes', 'approved', new_column_name='accepted')
+    if op.get_bind().dialect.name == 'sqlite':
+        with op.batch_alter_table('quotes') as batch_op:
+            batch_op.add_column(sa.Column('accepted', sa.Integer(), nullable=True))
+            batch_op.drop_column('approved')
+    else:
+        op.alter_column('quotes', 'approved', new_column_name='accepted')
 
 
 def downgrade():
-    op.alter_column('quotes', 'accepted', new_column_name='approved')
+    if op.get_bind().dialect.name == 'sqlite':
+        with op.batch_alter_table('quotes') as batch_op:
+            batch_op.add_column(sa.Column('approved', sa.Integer(), nullable=True))
+            batch_op.drop_column('accepted')
+    else:
+        op.alter_column('quotes', 'accepted', new_column_name='approved')


### PR DESCRIPTION
Fixes issue #1297, at least partially. The datetime conversions are probably hopeless, my limited Googling couldn't any way to do it, but this at least makes the upgrades a little easier (and will generate SQLite-compatble migrations as much as possible from here forward)